### PR TITLE
Fix group markers don't check for tracker

### DIFF
--- a/addons/friendly_tracker/XEH_PREP.hpp
+++ b/addons/friendly_tracker/XEH_PREP.hpp
@@ -9,3 +9,4 @@ PREP(createVehicleMarker);
 PREP(getGroupMarkerType);
 PREP(getVehicleMarkerType);
 PREP(hasTracker);
+PREP(isTrackable);

--- a/addons/friendly_tracker/functions/fnc_hasTracker.sqf
+++ b/addons/friendly_tracker/functions/fnc_hasTracker.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: 3Mydlo3
  * Function checks if unit has tracking device in equipment

--- a/addons/friendly_tracker/functions/fnc_isTrackable.sqf
+++ b/addons/friendly_tracker/functions/fnc_isTrackable.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function checks if unit/group/vehicle is trackable.
+ * (if can be seen on the map and can see others)
+ *
+ * Arguments:
+ * 0: The thing that will be checked if it should be trackable <OBJECT/GROUP>
+ *
+ * Return Value:
+ * 0: Is trackable <BOOL>
+ *
+ * Example:
+ * [bob] call afft_friendly_tracker_fnc_isTrackable
+ *
+ * Public: No
+ */
+
+params ["_object"];
+
+// If GPS mode is disabled all object are trackable.
+if (!GVAR(GPS)) exitWith {true};
+
+if (_object isEqualType grpNull) then {
+    _object = leader _object;
+};
+
+// If object is vehicle check if anyone inside has tracker
+if (_object isKindOf "AllVehicles") exitWith {
+    (crew _object) findIf {[_x] call FUNC(hasTracker)} != -1
+};
+
+[_object] call FUNC(hasTracker);

--- a/addons/friendly_tracker/functions/fnc_loop.sqf
+++ b/addons/friendly_tracker/functions/fnc_loop.sqf
@@ -56,12 +56,14 @@ if ([player] call FUNC(isTrackable)) exitWith {
 // Create marker for groups if enabled
 switch (true) do {
     case (GVAR(showGroups) isEqualTo SHOW_PLAYER): {
-        [group player] call FUNC(createGroupMarker);
+        private _group = group player;
+        if (!([_group] call FUNC(isTrackable))) exitWith {};
+        [_group] call FUNC(createGroupMarker);
     };
     case (GVAR(showGroups) isEqualTo SHOW_ALL): {
         {
             [_x] call FUNC(createGroupMarker);
-        } forEach (allGroups select {isPlayer leader _x});
+        } forEach (allGroups select {isPlayer leader _x && {[_x] call FUNC(isTrackable)}});
     };
 };
 

--- a/addons/friendly_tracker/functions/fnc_loop.sqf
+++ b/addons/friendly_tracker/functions/fnc_loop.sqf
@@ -27,14 +27,14 @@ if (!GVAR(enabled)) exitWith {
 GVAR(markers) = [];
 
 // If GPS mode is enabled and player (local) does not have GPS/UAV terminal we break and schedule next loop
-if (GVAR(GPS) && {!([player] call FUNC(hasTracker))}) exitWith {
+if ([player] call FUNC(isTrackable)) exitWith {
     [FUNC(loop), [], GVAR(refreshRate)] call CBA_fnc_waitAndExecute;
 };
 
 // Create marker for every player in game
 {
     // If GPS mode is enabled and player does not have GPS/UAV terminal we skip him and go to the next one
-    if (!GVAR(GPS) || {GVAR(GPS) && {[_x] call FUNC(hasTracker)}}) then {
+    if ([_x] call FUNC(isTrackable)) then {
         // Check if player is not in vehicle or vehicle markers are off
         if (isNull objectParent _x || {!GVAR(showVehicle)}) then {
             [_x] call FUNC(createPlayerMarker);


### PR DESCRIPTION
**When merged this pull request will:**
- `FUNC(hasTracker)` add missing script_component include
- Create `FUNC(isTrackable)` which checks if object (unit, group, vehicle) can be seen on the map, and (for players) can see other trackable players.
- Check if group is trackable before creating marker

Fixes #11