### PR TITLE
Show all group markers by default

### DIFF
--- a/addons/friendly_tracker/initSettings.sqf
+++ b/addons/friendly_tracker/initSettings.sqf
@@ -35,7 +35,7 @@
     "LIST",
     [LSTRING(showGroups), LSTRING(showGroups_Description)],
     LSTRING(DisplayName),
-    [[0, 1, 2], [LSTRING(showGroups_Disabled), LSTRING(showGroups_Player), LSTRING(showGroups_All)], 0],
+    [[0, 1, 2], [LSTRING(showGroups_Disabled), LSTRING(showGroups_Player), LSTRING(showGroups_All)], 2],
     false
 ] call CBA_fnc_addSetting;
 


### PR DESCRIPTION
**When merged this pull request will:**
- title

They are still optional and possible to turn off locally.

Close #26