### PR TITLE
Add ability to select trackable sides

### DIFF
--- a/addons/friendly_tracker/XEH_PREP.hpp
+++ b/addons/friendly_tracker/XEH_PREP.hpp
@@ -10,5 +10,6 @@ PREP(getGroupMarkerType);
 PREP(getVehicleMarkerType);
 
 PREP(canTrack);
+PREP(getTrackedSides);
 PREP(hasTracker);
 PREP(isTrackable);

--- a/addons/friendly_tracker/XEH_preInit.sqf
+++ b/addons/friendly_tracker/XEH_preInit.sqf
@@ -4,6 +4,9 @@ ADDON = false;
 
 #include "initSettings.sqf"
 
+// Friendly sides cache
+GVAR(trackedSides) = [playerSide];
+
 GVAR(running) = false;
 GVAR(markers) = [];
 GVAR(trackedVehicles) = [];

--- a/addons/friendly_tracker/functions/fnc_createGroupMarker.sqf
+++ b/addons/friendly_tracker/functions/fnc_createGroupMarker.sqf
@@ -29,7 +29,7 @@ if (!(_leader isEqualTo _vehicleLeader) && {GVAR(showVehicle)}) exitWith {
 };
 
 // Standard marker creation
-private _marker = format [QGVAR(group_%1), _groupName];
+private _marker = format [QGVAR(group_%1), _group];
 createMarkerLocal [_marker, getPos _leader];
 _marker setMarkerTypeLocal ([_group] call FUNC(getGroupMarkerType));
 _marker setMarkerSizeLocal [0.75, 0.75];

--- a/addons/friendly_tracker/functions/fnc_getTrackedSides.sqf
+++ b/addons/friendly_tracker/functions/fnc_getTrackedSides.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Returns trackable sides for given side.
+ *
+ * Arguments:
+ * 0: Side for which we want trackable sides <SIDE>
+ *
+ * Return Value:
+ * 0: Array of trackable sides <ARRAY>
+ *
+ * Example:
+ * call afft_friendly_tracker_fnc_getTrackedSides
+ *
+ * Public: No
+ */
+
+params [["_side", playerSide]];
+
+private _trackedSides = switch (GVAR(showSides)) do {
+    case (SIDES_FRIENDLY): {([_side] call BIS_fnc_friendlySides) - [sideFriendly]};
+    case (SIDES_PLAYER): {[_side]};
+    case (SIDES_ALL): {[WEST, EAST, INDEPENDENT]};
+};
+
+if (GVAR(showSideCivilian)) then {
+    _trackedSides pushBackUnique CIVILIAN;
+} else {
+    if (_side isEqualTo CIVILIAN) exitWith {};
+    _trackedSides = _trackedSides - [CIVILIAN];
+};
+
+_trackedSides

--- a/addons/friendly_tracker/functions/fnc_getTrackedSides.sqf
+++ b/addons/friendly_tracker/functions/fnc_getTrackedSides.sqf
@@ -19,15 +19,12 @@ params [["_side", playerSide]];
 
 private _trackedSides = switch (GVAR(showSides)) do {
     case (SIDES_FRIENDLY): {([_side] call BIS_fnc_friendlySides) - [sideFriendly]};
-    case (SIDES_PLAYER): {[_side]};
-    case (SIDES_ALL): {[WEST, EAST, INDEPENDENT]};
+    case (SIDES_PLAYER): {[_side, CIVILIAN]};
+    case (SIDES_ALL): {[WEST, EAST, INDEPENDENT, CIVILIAN]};
 };
 
-if (GVAR(showSideCivilian)) then {
-    _trackedSides pushBackUnique CIVILIAN;
-} else {
-    if (_side isEqualTo CIVILIAN) exitWith {};
-    _trackedSides = _trackedSides - [CIVILIAN];
+if (!GVAR(showSideCivilian) && {_side != CIVILIAN}) exitWith {
+    _trackedSides - [CIVILIAN] // return
 };
 
-_trackedSides
+_trackedSides // return

--- a/addons/friendly_tracker/functions/fnc_loop.sqf
+++ b/addons/friendly_tracker/functions/fnc_loop.sqf
@@ -32,18 +32,7 @@ if (!([player] call FUNC(canTrack))) exitWith {
 };
 
 // Determine which sides we want to track
-GVAR(trackedSides) = switch (GVAR(showSides)) do {
-    case (SIDES_FRIENDLY): {([playerSide] call BIS_fnc_friendlySides) - [sideFriendly]};
-    case (SIDES_PLAYER): {[playerSide]};
-    case (SIDES_ALL): {[WEST, EAST, INDEPENDENT]};
-};
-
-if (GVAR(showSideCivilian)) then {
-    GVAR(trackedSides) pushBackUnique CIVILIAN;
-} else {
-    if (playerSide isEqualTo CIVILIAN) exitWith {};
-    GVAR(trackedSides) = GVAR(trackedSides) - [CIVILIAN];
-};
+GVAR(trackedSides) = call FUNC(getTrackedSides);
 
 // Create marker for every player in game
 {

--- a/addons/friendly_tracker/functions/fnc_loop.sqf
+++ b/addons/friendly_tracker/functions/fnc_loop.sqf
@@ -31,6 +31,13 @@ if (!([player] call FUNC(canTrack))) exitWith {
     [FUNC(loop), [], GVAR(refreshRate)] call CBA_fnc_waitAndExecute;
 };
 
+// Determine which sides we want to track
+GVAR(trackedSides) = switch (GVAR(showSides)) do {
+    case (SIDES_FRIENDLY): {([playerSide] call BIS_fnc_friendlySides) - [sideFriendly, CIVILIAN]};
+    case (SIDES_PLAYER): {[playerSide]};
+    case (SIDES_ALL): {[WEST, EAST, INDEPENDENT]};
+};
+
 // Create marker for every player in game
 {
     // If player is not trackable we skip him and go to the next one

--- a/addons/friendly_tracker/functions/fnc_loop.sqf
+++ b/addons/friendly_tracker/functions/fnc_loop.sqf
@@ -33,13 +33,16 @@ if (!([player] call FUNC(canTrack))) exitWith {
 
 // Determine which sides we want to track
 GVAR(trackedSides) = switch (GVAR(showSides)) do {
-    case (SIDES_FRIENDLY): {([playerSide] call BIS_fnc_friendlySides) - [sideFriendly, CIVILIAN]};
+    case (SIDES_FRIENDLY): {([playerSide] call BIS_fnc_friendlySides) - [sideFriendly]};
     case (SIDES_PLAYER): {[playerSide]};
     case (SIDES_ALL): {[WEST, EAST, INDEPENDENT]};
 };
 
 if (GVAR(showSideCivilian)) then {
-    GVAR(trackedSides) pushBack CIVILIAN;
+    GVAR(trackedSides) pushBackUnique CIVILIAN;
+} else {
+    if (playerSide isEqualTo CIVILIAN) exitWith {};
+    GVAR(trackedSides) = GVAR(trackedSides) - [CIVILIAN];
 };
 
 // Create marker for every player in game

--- a/addons/friendly_tracker/functions/fnc_loop.sqf
+++ b/addons/friendly_tracker/functions/fnc_loop.sqf
@@ -38,6 +38,10 @@ GVAR(trackedSides) = switch (GVAR(showSides)) do {
     case (SIDES_ALL): {[WEST, EAST, INDEPENDENT]};
 };
 
+if (GVAR(showSideCivilian)) then {
+    GVAR(trackedSides) pushBack CIVILIAN;
+};
+
 // Create marker for every player in game
 {
     // If player is not trackable we skip him and go to the next one

--- a/addons/friendly_tracker/initSettings.sqf
+++ b/addons/friendly_tracker/initSettings.sqf
@@ -49,6 +49,15 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(showSideCivilian),
+    "CHECKBOX",
+    [LSTRING(ShowSideCivilian), LSTRING(ShowSideCivilian_Description)],
+    LSTRING(DisplayName),
+    true,
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(showUnconc),
     "CHECKBOX",
     [LSTRING(ShowUnconc), LSTRING(ShowUnconc_Description)],

--- a/addons/friendly_tracker/initSettings.sqf
+++ b/addons/friendly_tracker/initSettings.sqf
@@ -44,7 +44,7 @@
     "LIST",
     [LSTRING(showSides), LSTRING(showSides_Description)],
     LSTRING(DisplayName),
-    [[SIDES_FRIENDLY, SIDES_PLAYER, SIDES_ALL], [LSTRING(showSides_Friendly), LSTRING(showSides_Player), LSTRING(showSides_All)], SIDES_FRIENDLY],
+    [[SIDES_FRIENDLY, SIDES_PLAYER, SIDES_ALL], [LSTRING(showSides_Friendly), LSTRING(showSides_Player), LSTRING(showSides_All)], 0],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/friendly_tracker/initSettings.sqf
+++ b/addons/friendly_tracker/initSettings.sqf
@@ -45,7 +45,7 @@
     [LSTRING(showSides), LSTRING(showSides_Description)],
     LSTRING(DisplayName),
     [[SIDES_FRIENDLY, SIDES_PLAYER, SIDES_ALL], [LSTRING(showSides_Friendly), LSTRING(showSides_Player), LSTRING(showSides_All)], SIDES_FRIENDLY],
-    false
+    true
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/friendly_tracker/initSettings.sqf
+++ b/addons/friendly_tracker/initSettings.sqf
@@ -40,6 +40,15 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(showSides),
+    "LIST",
+    [LSTRING(showSides), LSTRING(showSides_Description)],
+    LSTRING(DisplayName),
+    [[SIDES_FRIENDLY, SIDES_PLAYER, SIDES_ALL], [LSTRING(showSides_Friendly), LSTRING(showSides_Player), LSTRING(showSides_All)], SIDES_FRIENDLY],
+    false
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(showUnconc),
     "CHECKBOX",
     [LSTRING(ShowUnconc), LSTRING(ShowUnconc_Description)],

--- a/addons/friendly_tracker/initSettings.sqf
+++ b/addons/friendly_tracker/initSettings.sqf
@@ -53,7 +53,7 @@
     "CHECKBOX",
     [LSTRING(ShowSideCivilian), LSTRING(ShowSideCivilian_Description)],
     LSTRING(DisplayName),
-    true,
+    false,
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/friendly_tracker/script_component.hpp
+++ b/addons/friendly_tracker/script_component.hpp
@@ -15,9 +15,13 @@
 #include "\z\afft\addons\main\script_macros.hpp"
 
 #ifdef DEBUG_MODE_SHOW_AI
-    #define TRACKABLE_UNITS  (allUnits select {side _x isEqualTo playerSide})
-    #define TRACKABLE_GROUPS (allGroups select {side _x isEqualTo playerSide && {[_x] call FUNC(isTrackable)}})
+    #define TRACKABLE_UNITS  (allUnits select {side _x in GVAR(friendlySides)})
+    #define TRACKABLE_GROUPS (allGroups select {side _x in GVAR(friendlySides) && {[_x] call FUNC(isTrackable)}})
 #else
-    #define TRACKABLE_UNITS  (allPlayers select {side _x isEqualTo playerSide})
-    #define TRACKABLE_GROUPS (allGroups select {isPlayer leader _x && {side _x isEqualTo playerSide && {[_x] call FUNC(isTrackable)}}})
+    #define TRACKABLE_UNITS  (allPlayers select {side _x in GVAR(friendlySides)})
+    #define TRACKABLE_GROUPS (allGroups select {isPlayer leader _x && {side _x in GVAR(friendlySides) && {[_x] call FUNC(isTrackable)}}})
 #endif
+
+#define SIDES_FRIENDLY 0
+#define SIDES_PLAYER 1
+#define SIDES_ALL 2

--- a/addons/friendly_tracker/script_component.hpp
+++ b/addons/friendly_tracker/script_component.hpp
@@ -15,11 +15,11 @@
 #include "\z\afft\addons\main\script_macros.hpp"
 
 #ifdef DEBUG_MODE_SHOW_AI
-    #define TRACKABLE_UNITS  (allUnits select {side _x in GVAR(friendlySides)})
-    #define TRACKABLE_GROUPS (allGroups select {side _x in GVAR(friendlySides) && {[_x] call FUNC(isTrackable)}})
+    #define TRACKABLE_UNITS  (allUnits select {side _x in GVAR(trackedSides)})
+    #define TRACKABLE_GROUPS (allGroups select {side _x in GVAR(trackedSides) && {[_x] call FUNC(isTrackable)}})
 #else
-    #define TRACKABLE_UNITS  (allPlayers select {side _x in GVAR(friendlySides)})
-    #define TRACKABLE_GROUPS (allGroups select {isPlayer leader _x && {side _x in GVAR(friendlySides) && {[_x] call FUNC(isTrackable)}}})
+    #define TRACKABLE_UNITS  (allPlayers select {side _x in GVAR(trackedSides)})
+    #define TRACKABLE_GROUPS (allGroups select {isPlayer leader _x && {side _x in GVAR(trackedSides) && {[_x] call FUNC(isTrackable)}}})
 #endif
 
 #define SIDES_FRIENDLY 0

--- a/addons/friendly_tracker/stringtable.xml
+++ b/addons/friendly_tracker/stringtable.xml
@@ -69,6 +69,14 @@
             <English>All sides</English>
             <Polish>Wszystkie strony</Polish>
         </Key>
+        <Key ID="STR_AFFT_Friendly_Tracker_ShowSideCivilian">
+            <English>Show civilian side</English>
+            <Polish>Pokazuj stronę cywilną</Polish>
+        </Key>
+        <Key ID="STR_AFFT_Friendly_Tracker_ShowSideCivilian_Description">
+            <English>If enabled civilian side will be added to tracker.</English>
+            <Polish>Włączenie tej opcji powoduje dodanie strony cywilnej do trackera.</Polish>
+        </Key>
         <Key ID="STR_AFFT_Friendly_Tracker_ShowUnconc">
             <English>Show unconscious</English>
             <Polish>Pokazuj nieprzytomnych</Polish>

--- a/addons/friendly_tracker/stringtable.xml
+++ b/addons/friendly_tracker/stringtable.xml
@@ -49,6 +49,26 @@
             <English>All groups</English>
             <Polish>Wszystkie grupy</Polish>
         </Key>
+        <Key ID="STR_AFFT_Friendly_Tracker_ShowSides">
+            <English>Show sides</English>
+            <Polish>Pokazuj strony</Polish>
+        </Key>
+        <Key ID="STR_AFFT_Friendly_Tracker_ShowSides_Description">
+            <English>Controls shich sides will be visible on tracker.</English>
+            <Polish>Kontroluje które strony będą widoczne na trackerze.</Polish>
+        </Key>
+        <Key ID="STR_AFFT_Friendly_Tracker_ShowSides_Friendly">
+            <English>Friendly sides</English>
+            <Polish>Sojusznicze strony</Polish>
+        </Key>
+        <Key ID="STR_AFFT_Friendly_Tracker_ShowSides_Player">
+            <English>Only player's side</English>
+            <Polish>Tylko strona gracza</Polish>
+        </Key>
+        <Key ID="STR_AFFT_Friendly_Tracker_ShowSides_All">
+            <English>All sides</English>
+            <Polish>Wszystkie strony</Polish>
+        </Key>
         <Key ID="STR_AFFT_Friendly_Tracker_ShowUnconc">
             <English>Show unconscious</English>
             <Polish>Pokazuj nieprzytomnych</Polish>

--- a/addons/friendly_tracker/stringtable.xml
+++ b/addons/friendly_tracker/stringtable.xml
@@ -74,8 +74,8 @@
             <Polish>Pokazuj stronę cywilną</Polish>
         </Key>
         <Key ID="STR_AFFT_Friendly_Tracker_ShowSideCivilian_Description">
-            <English>If enabled civilian side will be added to tracker.</English>
-            <Polish>Włączenie tej opcji powoduje dodanie strony cywilnej do trackera.</Polish>
+            <English>If enabled civilian side will be added to tracker. If disabled civilian side will still see itself on tracker.</English>
+            <Polish>Włączenie tej opcji powoduje dodanie strony cywilnej do trackera. Jeżeli ta opcja jest wyłączona to jednostki cywilne wciąż widzą same siebie na trackerze.</Polish>
         </Key>
         <Key ID="STR_AFFT_Friendly_Tracker_ShowUnconc">
             <English>Show unconscious</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Allow to choose which sides should be tracked:
  - Player side only (current behaviour)
  - Friendly sides (eg. BLUFOR + INDFOR)
  - All sides (BLUFOR + REDFOR + INDFOR)
- Allow to choose if civilian side should be tracked also (only for non-civilian sides)